### PR TITLE
#391 - Images on the tools page overlap with following sections

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -150,6 +150,7 @@ h2.nomargin {
 
 h3 {
   margin-top: 1.5em;
+  clear: both;
 }
 
 .infolabel {


### PR DESCRIPTION
- add `clear: both` on h3 as discussed in #391