### PR TITLE
aux should have no dependants

### DIFF
--- a/_u-overview/specific-syntax.md
+++ b/_u-overview/specific-syntax.md
@@ -121,7 +121,7 @@ advmod(is-6, too-8)
 ~~~ sdparse
 They will do it if they want to .
 
-nsubj(will-2, They-1)
+nsubj(do-3, They-1)
 aux(do-3, will-2)
 obj(do-3, it-4)
 advcl(do-3, want-7)


### PR DESCRIPTION
There are just 4 exceptions in [the specification](http://universaldependencies.org/u/overview/syntax.html#the-status-of-function-words) which do not apply here.
I believe this `nsubj` depending on `aux` is an error.