### PR TITLE
Clarification of goeswith

### DIFF
--- a/_u-dep/goeswith.md
+++ b/_u-dep/goeswith.md
@@ -5,11 +5,19 @@ shortdef: 'goes with'
 udver: '2'
 ---
 
-This relation links two parts of a word that are separated in text
-that is not well edited.
-The head is in some sense the “main” part, often the second part.
+This relation links two or more parts of a word that are separated in text that is not well edited.
+These parts should be written together as one word according to the ortographic rules of a given language.
+The head is always the first part, the other parts are attached to it with the `goeswith` relation
+(for consistency, similarly as in [flat](), [fixed]() and [conj]()).
+Note that only the last part may be annotated with `SpaceAfter=No`.
 
 ~~~ sdparse
 They come here with out legal permission
-goeswith(out-5, with-4)
+goeswith(with-4, out-5)
+~~~
+
+~~~ sdparse
+never the less/[SpaceAfter=No] ,
+goeswith(never, the)
+goeswith(never, less)
 ~~~


### PR DESCRIPTION
As agreed in #414, `goeswith` should form a head-initial flat structure, not a chain.