### PR TITLE
Fix link to en-comparison at _en/index.md

### DIFF
--- a/_en/index.md
+++ b/_en/index.md
@@ -57,7 +57,7 @@ There are six English UD treebanks:
 
 Comparative statistics for tags in the treebanks are available here:
 
-[http://universaldependencies.org/treebanks/en-comparison.html]()
+[https://universaldependencies.org/treebanks/en-comparison.html]()
 
 
 


### PR DESCRIPTION
Currently the HTML being generated by the link at the end looks like this:

```html
<a href="" title="failed to link &quot;http://universaldependencies.org/treebanks/en-comparison.html&quot; to any entry in any collection" style="color: red;">http://universaldependencies.org/treebanks/en-comparison.html</a>
```
I think what must have happened is that the URL wasn't recognized because it started with `http://` instead of `https://`. Maybe this will correct the error.