### PR TITLE
Fix typos, wrongly annotated examples and brat rendering issues.

### DIFF
--- a/_eu/dep/advcl.md
+++ b/_eu/dep/advcl.md
@@ -17,7 +17,7 @@ Askatasunean oinarritutako alternatiba bat ematea . \n  Freedom based_on alterna
 
 nmod(oinarritutako-2, Askatasunean-1)
 advcl(alternatiba-3, oinarritutako-2)
-nummod(aternatiba-3, bat-4)
+nummod(alternatiba-3, bat-4)
 dobj(ematea-5, alternatiba-3)
 punct(ematea-5, .-6)
 ~~~

--- a/_eu/dep/advmod.md
+++ b/_eu/dep/advmod.md
@@ -14,13 +14,15 @@ We differentiate adverbials realized as adverbs _(advmod)_ and adverbials realiz
 *Rich, **however**, is not **alone** .*
 
 ~~~ sdparse
-Rich, ordea, ez dago bakarrik . \n Rich, however, is not alone .
+Rich , ordea , ez dago bakarrik . \n Rich , however , is not alone .
 
-nsubj(dago-4, Rich-1)
-advmod(dago-4, ordea-2)
-neg(dago-4, ez-3)
-advmod(dago-4, bakarrik-5)
-punct(dago-4, .-6)
+nsubj(dago-6, Rich-1)
+advmod(dago-6, ordea-3)
+neg(dago-6, ez-5)
+advmod(dago-6, bakarrik-7)
+punct(dago-6, .-8)
+punct(dago-6, ,-2)
+punct(dago-6, ,-4)
 ~~~
 
 

--- a/_eu/dep/appos.md
+++ b/_eu/dep/appos.md
@@ -12,7 +12,7 @@ An appositional modifier of a noun (`appos`) is a nominal immediately following 
 *They killed a couple in Chinani, in the Taref **province** .*
 
 ~~~ sdparse
-Bikote bat hil zuten Chinanin, Taref probintzian . \n Couple a killed Chinani_in, Taref province_the_in .
+Bikote bat hil zuten Chinanin , Taref probintzian . \n Couple a killed Chinani_in , Taref province_the_in .
 
 dobj(hil-3, Bikote-1)
 nummod(Bikote-1, bat-2)
@@ -30,15 +30,17 @@ punct(hil-3, .-9)
 *They explained it in the last assembly, in **the one made** in the 10th march .*
 
 ~~~ sdparse
-Azkenengo asanbladan, martxoaren 10ean eginikoa, adierazi zuten . \n They explained it in the last assembly, in the one made in the 10th march .
+Azkenengo asanbladan , martxoaren 10ean eginikoa , adierazi zuten . \n They explained it in the last assembly , in the one made in the 10th march .
 
 amod(asanbladan-2, Azkenengo-1)
-nmod(adierazi-6, asanbladan-2)
-nmod(10ean-4, martxoaren-3)
-nmod(eginikoa-5, 10ean-4)
-appos(asanbladan-2, eginikoa-5)
-aux(adierazi-6, zuten-7)
-punct(adierazi-6, .-8)
+nmod(adierazi-8, asanbladan-2)
+nmod(10ean-5, martxoaren-4)
+nmod(eginikoa-6, 10ean-5)
+appos(asanbladan-2, eginikoa-6)
+aux(adierazi-8, zuten-9)
+punct(adierazi-8, .-10)
+punct(asanbladan-2, ,-3)
+punct(asanbladan-2, ,-7)
 ~~~
 
 
@@ -47,22 +49,24 @@ punct(adierazi-6, .-8)
 *Agriculture and stockbreeding **(milk, meat and pork)** are the main autochthonous economic activities .*
 
 ~~~ sdparse
-Nekazaritza eta abeltzaintza (esnea, haragia eta txerriak) dira bertako iharduera ekonomiko nagusiak . n\ Agriculture and stockbreeding (milk, meat and pork) are autochthonous activities economic main_the .
+Nekazaritza eta abeltzaintza ( esnea , haragia eta txerriak ) dira bertako iharduera ekonomiko nagusiak . \n Agriculture and stockbreeding ( milk , meat and pork ) are autochthonous activities economic main_the .
 
 nsubj(iharduera-13, Nekazaritza)
 cc(Nekazaritza-1, eta-2)
 conj(Nekazaritza-1, abeltzaintza-3)
-appos(abeltzaintza-3, esnea-4)
-punct(esnea-4, ,-6)
-conj(esnea-4, haragia-6)
-cc(esnea-4, eta-7)
-conj(esnea-4, txerriak-8)
-appos(abeltzaintza-3, esnea-4)
-cop(iharduera-11, dira-9)
-amod(iharduera-11, bertako-10)
-amod(iharduera-11, ekonomiko-12)
-amod(iharduera-11, nagusiak-13)
-punct(iharduera-11, .-14)
+appos(abeltzaintza-3, esnea-5)
+punct(esnea-5, ,-6)
+conj(esnea-5, haragia-7)
+cc(esnea-5, eta-8)
+conj(esnea-5, txerriak-9)
+appos(abeltzaintza-3, esnea-5)
+cop(iharduera-13, dira-11)
+amod(iharduera-13, bertako-12)
+amod(iharduera-13, ekonomiko-14)
+amod(iharduera-13, nagusiak-15)
+punct(iharduera-13, .-16)
+punct(abeltzaintza-3, (-4)
+punct(iharduera-13, )-10)
 ~~~
 
 
@@ -71,19 +75,21 @@ punct(iharduera-11, .-14)
 *The italian Francesco Casagrandre continues in the first position of the Union Cycliste Internationale **(UCI)** .*
 
 ~~~ sdparse
-Francesco Casagrandre italiarrak Nazioarteko Txirrindularitza Elkarteko (UCI) lehen postuan jarraitzen du . n\ Francesco Casagrandre italian_the Internationale_the_of Cycliste Union (UCI) first position_the_in continues .
+Francesco Casagrandre italiarrak Nazioarteko Txirrindularitza Elkarteko ( UCI ) lehen postuan jarraitzen du . \n Francesco Casagrandre italian_the Internationale_the_of Cycliste Union ( UCI ) first position_the_in continues .
 
 nmod(italiarrak-3, Francesco-1)
 name(Francesco-1, Casagrandre-2)
-nsubj(jarraitzen-9, italiarrak-3)
-amod(lehen-8, Nazioarteko-4)
+nsubj(jarraitzen-12, italiarrak-3)
+amod(lehen-10, Nazioarteko-4)
 name(Nazioarteko-4, Txirrindularitza-5)
 name(Txirrindularitza-5, Elkarteko-6)
-appos(Elkarteko-6, UCI-7)
-det(postuan-9, lehen-8)
-nmod(jarraitzen-11, postuan)
-aux(jarraitzen-11, du-12)
-punct(jarraitzen-11, .-13)
+appos(Elkarteko-6, UCI-8)
+punct(UCI-8, (-7)
+punct(UCI-8, )-9)
+det(postuan-11, lehen-10)
+nmod(jarraitzen-12, postuan-11)
+aux(jarraitzen-12, du-13)
+punct(jarraitzen-12, .-14)
 ~~~
 
 

--- a/_eu/dep/aux_.md
+++ b/_eu/dep/aux_.md
@@ -22,7 +22,7 @@ Even if Basque word order is quite free, the auxiliary can only appear right aft
 *These two parts fold by the places that **are** marked .*
 
 ~~~ sdparse
-Bi zati hauek markaturik dauden tokietatik tolesten dira .\n Two parts these marked are_that sites_the_by fold .
+Bi zati hauek markaturik dauden tokietatik tolesten dira . \n Two parts these marked are_that sites_the_by fold .
 
 det(zati-2, Bi-1)
 nsubj(tolesten-7, zati-2)
@@ -42,7 +42,7 @@ punct(tolesten-7, .-9)
 *The change **has** caused a huge discussion .*
 
 ~~~ sdparse
-Eztabaida handia sortu du aldaketak .\n Discussion huge_a caused has change_the .
+Eztabaida handia sortu du aldaketak . \n Discussion huge_a caused has change_the .
 
 amod(Eztabaida-1, handia-2)
 nobj(sortu-3, Eztabaida-1)

--- a/_eu/dep/cc.md
+++ b/_eu/dep/cc.md
@@ -14,9 +14,8 @@ Coordination in the Basque UD annotation follows the general schema where the fi
 ***Zidane, Henry, Barthez, Deschamps, Blanc and the rest** form the most robust team of Europe according to most experts .*
 
 ~~~ sdparse
-Zidane, Henry, Barthez, Deschamps, Blanc eta enparauek Europako Talde sendoena osatzen dute aditu gehienentzat . \n Zidane, Henry, Barthez, Deschamps, Blanc and rest_the Europe_of team robust_the_most experts most_according_to .
+Zidane , Henry , Barthez , Deschamps , Blanc eta enparauek Europako talde sendoena osatzen dute aditu gehienentzat . \n Zidane , Henry , Barthez , Deschamps , Blanc and rest_the Europe_of team robust_the_most experts most_according_to .
 
-Zidane , Henry , Barthez , Deschamps , Blanc eta enparauek Europako talde sendoena osatzen dute aditu gehienentzat .
 punct(Henry-3, ,-2)
 conj(Zidane-1, Henry-3)
 punct(Barthez-5, ,-4)

--- a/_eu/dep/compound.md
+++ b/_eu/dep/compound.md
@@ -12,7 +12,7 @@ udver: '2'
 *Journalists were rowdy yesterday in the entrace of the officce that **Euskadi Foundation** has in Derio .*
 
 ~~~ sdparse
-Kazetariak aztoratuta ibili ziren atzo Euskadi Fundazioak Derion duen egoitzaren atarian .\n Journalists rowdy were yesterday Euskadi Foundation Derio_in has_that officce_of entrace_the_in .
+Kazetariak aztoratuta ibili ziren atzo Euskadi Fundazioak Derion duen egoitzaren atarian . \n Journalists rowdy were yesterday Euskadi Foundation Derio_in has_that officce_of entrace_the_in .
 
 nsubj(aztoratuta-2, Kazetariak-1)
 cop(aztoratuta-2, ibili-3)
@@ -41,6 +41,6 @@ nsubj(da-6, zerbait-3)
 compound(da-6, behar-5)
 nmod(bukatzeko-8, nirekin-7)
 advcl(da-6, bukatzeko-8)
-punct(da-6, .-)
+punct(da-6, .-9)
 ~~~
 <!-- Interlanguage links updated Pá kvě 14 11:08:56 CEST 2021 -->

--- a/_eu/dep/conj.md
+++ b/_eu/dep/conj.md
@@ -14,9 +14,8 @@ Coordination in the Basque UD annotation follows the general schema where the fi
 ***Zidane, Henry, Barthez, Deschamps, Blanc and the rest** form the most robust team of Europe according to most experts .*
 
 ~~~ sdparse
-Zidane, Henry, Barthez, Deschamps, Blanc eta enparauek Europako Talde sendoena osatzen dute aditu gehienentzat . \n Zidane, Henry, Barthez, Deschamps, Blanc and rest_the Europe_of team robust_the_most experts most_according_to .
+Zidane , Henry , Barthez , Deschamps , Blanc eta enparauek Europako talde sendoena osatzen dute aditu gehienentzat . \n Zidane , Henry , Barthez , Deschamps , Blanc and rest_the Europe_of team robust_the_most experts most_according_to .
 
-Zidane , Henry , Barthez , Deschamps , Blanc eta enparauek Europako talde sendoena osatzen dute aditu gehienentzat .
 punct(Henry-3, ,-2)
 conj(Zidane-1, Henry-3)
 punct(Barthez-5, ,-4)

--- a/_eu/dep/csubj.md
+++ b/_eu/dep/csubj.md
@@ -11,7 +11,7 @@ A clausal subject (`csubj`) is a clausal syntactic subject of a clause, i.e., th
 *It is now impossible **to deceive** .*
 
 ~~~ sdparse
-Orain ezinezkoa da engainatzea .\n Now impossible is to_deceive
+Orain ezinezkoa da engainatzea . \n Now impossible is to_deceive
 
 advmod(da-3, Orain-1)
 cop(ezinezkoa-2, da-3)
@@ -25,7 +25,7 @@ punct(ezinezkoa-2, .-5)
 *Here it is difficult **to take** someone as relative .*
 
 ~~~ sdparse
-Hemen inor etxekotzat hartzea zail egiten da .\n Here someone relative_as to_take difficult is .
+Hemen inor etxekotzat hartzea zail egiten da . \n Here someone relative_as to_take difficult is .
 
 adv(egiten-6, Hemen-1)
 dobj(hartzea-4,inor-2)

--- a/_eu/dep/det.md
+++ b/_eu/dep/det.md
@@ -57,7 +57,7 @@ Aukera asko daude . \n Options many there_are .
 
 det(Aukera-1, asko-2)
 cop(Aukera-1, daude-3)
-punct(Aukera-1-2, .-4)
+punct(Aukera-1, .-4)
 ~~~
 
 

--- a/_eu/dep/discourse.md
+++ b/_eu/dep/discourse.md
@@ -13,7 +13,7 @@ udver: '2'
 ***No**, I will not be alone eh !*
 
 ~~~ sdparse
-Ez, ez naiz bakarrik egoiten e ! \n No, I will not be alone eh !
+Ez , ez naiz bakarrik egoiten e ! \n No , I will not be alone eh !
 
 discourse(egoiten-6, Ez-1)
 neg(egoiten-6, ez-3)
@@ -28,12 +28,13 @@ punct(egoiten-6, !-8)
 ***So** it is not that, **no** .*
 
 ~~~ sdparse
-Ba ez da hori, ez . \n So it is not that, no .
+Ba ez da hori , ez . \n So it is not that , no .
 
 discourse(da-3, Ba-1)
 neg(da-3, ez-2)
 nsubj(da-3, hori-4)
-discourse(da-3, ez-5)
-punct(da-3, .-6)
+discourse(da-3, ez-6)
+punct(da-3, .-7)
+punct(da-3, ,-5)
 ~~~
 <!-- Interlanguage links updated Pá kvě 14 11:09:03 CEST 2021 -->

--- a/_eu/dep/fixed.md
+++ b/_eu/dep/fixed.md
@@ -12,21 +12,23 @@ udver: '2'
 *After leaving school, he/she learns some other things, **among others** piano and art .*
 
 ~~~ sdparse
-Eskolatik irten ondoren, beste hainbat gauza ikasten dituzte, besteak beste pianoa eta artea . \n After leaving school, he/she also learns some other things, among others piano and art .
+Eskolatik irten ondoren , beste hainbat gauza ikasten dituzte , besteak beste pianoa eta artea . \n After leaving school , he/she also learns some other things , among others piano and art .
 
 nmod(irten-2, Eskolatik-1)
-advcl(ikasten-7, irten-2)
+advcl(ikasten-8, irten-2)
 advcl(irten-2, ondoren-3)
-det(hainbat-5, beste-4)
-det(gauza-6, hainbat-5)
-dobj(ikasten-7, gauza-6)
-aux(ikasten-7, dituzte-8)
-advmod(besteak-9, ikasten-7)
-mwe(besteak-9, beste-10)
-conj(beste-10, pianoa-11)
-cc(pianoa-11, eta-12)
-conj(pianoa-11, artea-13)
-punct(besteak-9, .-14)
+det(hainbat-6, beste-5)
+det(gauza-7, hainbat-6)
+dobj(ikasten-8, gauza-7)
+aux(ikasten-8, dituzte-9)
+advmod(besteak-11, ikasten-8)
+mwe(besteak-11, beste-12)
+conj(beste-12, pianoa-13)
+cc(pianoa-13, eta-14)
+conj(pianoa-13, artea-15)
+punct(besteak-11, .-16)
+punct(besteak-11, ,-4)
+punct(besteak-11, ,-10)
 ~~~
 
 
@@ -35,19 +37,18 @@ punct(besteak-9, .-14)
 *He/she is stronger than Hakkinen, **as clear as water** .*
 
 ~~~ sdparse
-Hakkinen baino sendoago ari da, argi eta garbi . \n Hakkinen than stronger is, as clear as water .
+Hakkinen baino sendoago ari da , argi eta garbi . \n Hakkinen than stronger is , as clear as water .
 
 nsubj(baino-2, Hakkinen-1)
 advmod(da-5, baino-2)
 aux(da-5, ari-4)
 cop(sendoago-3, da-5)
-advmod(da-5, argi-6)
-mwe(argi-6, eta-7)
-mwe(argi-6, garbi-8)
-punct(sendoago-3, .-9)
+advmod(da-5, argi-7)
+mwe(argi-7, eta-8)
+mwe(argi-7, garbi-9)
+punct(sendoago-3, .-10)
+punct(sendoago-3, ,-6)
 ~~~
-
-
 
 
 <!-- Interlanguage links updated Pá kvě 14 11:09:05 CEST 2021 -->

--- a/_eu/dep/iobj.md
+++ b/_eu/dep/iobj.md
@@ -12,13 +12,14 @@ The indirect object (`iobj`) of a verb is any nominal phrase that is a core argu
 *(He/she told **the students** that they needed to study in the evening .*
 
 ~~~ sdparse
-Ikasleei esan zien arratsaldean ikasi behar zutela .\n Students_the_to told evening_the_in to_study needed_that
+Ikasleei esan zien arratsaldean ikasi behar zutela . \n Students_the_to told evening_the_in to_study needed_that
 
 iobj(esan-2, Ikasleei-1)
 aux(esan-2, zien-3)
 nmod(esan-2, arratsaldean-4)
-xcomp(behar_zutela-6, ikasi-5)
-ccomp(esan-2, behar_zutela-6)
+xcomp(behar-6, ikasi-5)
+ccomp(esan-2, behar-6)
+compound(behar-6, zutela-7)
 punct(esan-2, .-8)
 ~~~
 
@@ -28,7 +29,7 @@ punct(esan-2, .-8)
 *(He/she) has made a great effort teaching **us** geography .*
 
 ~~~ sdparse
-Ahalegin haundia egin du guri geografia irakasten .\n  Effort great_a made has us geography teaching .
+Ahalegin haundia egin du guri geografia irakasten .i \n  Effort great_a made has us geography teaching .
 
 amod(Ahalegin-1, haundia-2)
 dobj(egin-3, Ahalegin-1)
@@ -45,7 +46,7 @@ punct(egin-3, .-8)
 *Djukanovic has given a big change to his political **course** .*
 
 ~~~ sdparse
-Djukanovicek aldaketa handia eman dio bere ildo politikoari .\n Djukanovic change big_a given has his course political_to .
+Djukanovicek aldaketa handia eman dio bere ildo politikoari . \n Djukanovic change big_a given has his course political_to .
 
 nsubj(eman-4, Djukanovicek-1)
 dobj(eman-4, aldaketa-2)

--- a/_eu/dep/mark.md
+++ b/_eu/dep/mark.md
@@ -28,7 +28,7 @@ punct(hausnartzen-3, .-6)
 
 
 ~~~ sdparse
-Orio eta Castro garaipena lortzeko hautagaiak ziren arren, maila makala erakutsi zuten estropada hasieratik . \n  Orio and Castro victory_the obtain_to candidates_the were Although, level low_a showed regata_the_of beginning_the_from  .
+Orio eta Castro garaipena lortzeko hautagaiak ziren arren , maila makala erakutsi zuten estropada hasieratik . \n  Orio and Castro victory_the obtain_to candidates_the were Although, level low_a showed regata_the_of beginning_the_from  .
 
 nsubj(hautagaiak-6, Orio-1)
 cc(Orio-1, eta-2)
@@ -44,29 +44,31 @@ aux(erakutsi-12, zuten-13)
 nmod(hasieratik-15, estropada-14)
 nmod(erakutsi-12, hasieratik-15)
 punct(erakutsi-12, .-16)
+punct(erakutsi-12, ,-9)
 ~~~
 
 
-*ez dugu hemen azalduko, Mirande eta Kristautasuna saioan egina dago **eta** gehienbat .*
+*Ez dugu hemen azalduko, Mirande eta Kristautasuna saioan egina dago **eta** gehienbat .*
 
 *We will not show it here, mainly **because** it is done in the session Mirande and Cristianity .*
 
 
 ~~~ sdparse
-ez dugu hemen azalduko, Mirande eta Kristautasuna saioan egina dago eta gehienbat . \nWe will not show it here, mainly because it is done in the session Mirande and Cristianity .
+Ez dugu hemen azalduko , Mirande eta Kristautasuna saioan egina dago eta gehienbat . \n We will not show it here , mainly because it is done in the session Mirande and Cristianity .
 
-advmod(azalduko-4, ez-1)
+advmod(azalduko-4, Ez-1)
 aux(azalduko-4, dugu-2)
 advmod(azalduko-4, hemen-3)
-nmod(saioan-8, Mirande-5)
-cc(Mirande-5, eta-6)
-conj(Mirande-5, Kristautasuna-7)
-nmod(egina-9, saioan-8)
-advcl(azalduko-4, egina-9)
-cop(egina-9, dago-10)
-mark(dago-10, eta-11)
-advmod(dago-10, gehienbat-12)
-punct(azalduko-4, .-13)
+nmod(saioan-9, Mirande-6)
+cc(Mirande-6, eta-7)
+conj(Mirande-6, Kristautasuna-8)
+nmod(egina-10, saioan-9)
+advcl(azalduko-4, egina-10)
+cop(egina-10, dago-11)
+mark(dago-11, eta-12)
+advmod(dago-11, gehienbat-13)
+punct(azalduko-4, .-14)
+punct(azalduko-4, ,-5)
 ~~~
 
 <!-- Interlanguage links updated Pá kvě 14 11:09:08 CEST 2021 -->

--- a/_eu/dep/nsubj.md
+++ b/_eu/dep/nsubj.md
@@ -14,7 +14,7 @@ Example of a subject in an intransitive sentence (ABS case):
 *These two **parts** fold by the sites that are marked .*
 
 ~~~ sdparse
-Bi zati hauek markaturik dauden tokietatik tolesten dira .\n Two parts these marked are_that sites_the_by fold .
+Bi zati hauek markaturik dauden tokietatik tolesten dira . \n Two parts these marked are_that sites_the_by fold .
 
 det(zati-2, Bi-1)
 nsubj(tolesten-7, zati-2)
@@ -34,7 +34,7 @@ Example of a subject in a transitive sentence (ERG case):
 *The **change** has caused a huge discussion .*
 
 ~~~ sdparse
-Eztabaida handia sortu du aldaketak .\n Discussion huge_a caused has change_the .
+Eztabaida handia sortu du aldaketak . \n Discussion huge_a caused has change_the .
 
 amod(Eztabaida-1, handia-2)
 dobj(sortu-3, Eztabaida-1)
@@ -44,7 +44,6 @@ punct(sortu-3, .-6)
 ~~~
 
 
-
 Being Basque a free word order language, arguments of the verb can appear in different orders with respect to the verb.
 
 ***Aldaketak** eztabaida handia sortu du .*
@@ -52,7 +51,7 @@ Being Basque a free word order language, arguments of the verb can appear in dif
 *The **change** has caused a huge discussion .*
 
 ~~~ sdparse
-Aldaketak eztabaida handia sortu du .\n Change_the discussion huge_a caused has .
+Aldaketak eztabaida handia sortu du . \n Change_the discussion huge_a caused has .
 
 nsubj(sortu-4, Aldaketak-1)
 amod(eztabaida-2, handia-3)

--- a/_eu/dep/obj.md
+++ b/_eu/dep/obj.md
@@ -12,7 +12,7 @@ The direct object (`obj`) of a verb is the noun phrase that denotes the entity a
 *(He/she) reminded that Basque society refused the **Constitution** .*
 
 ~~~ sdparse
-Euskal gizarteak Konstituzioa errefusatu zuela oroitarazi zuen .\n Basque society Constitution_the refused_that reminded .
+Euskal gizarteak Konstituzioa errefusatu zuela oroitarazi zuen . \n Basque society Constitution_the refused_that reminded .
 
 nmod(Euskal-1, gizarteak-2)
 nsubj(errefusatu-4, gizarteak-2)

--- a/_eu/dep/punct.md
+++ b/_eu/dep/punct.md
@@ -22,9 +22,8 @@ Coordination in the Basque UD annotation follows the general schema where the fi
 ***Zidane, Henry, Barthez, Deschamps, Blanc and the rest** form the most robust team of Europe according to most experts .*
 
 ~~~ sdparse
-Zidane, Henry, Barthez, Deschamps, Blanc eta enparauek Europako Talde sendoena osatzen dute aditu gehienentzat . \n Zidane, Henry, Barthez, Deschamps, Blanc and rest_the Europe_of team robust_the_most experts most_according_to .
+Zidane , Henry , Barthez , Deschamps , Blanc eta enparauek Europako talde sendoena osatzen dute aditu gehienentzat . \n Zidane , Henry , Barthez , Deschamps , Blanc and rest_the Europe_of team robust_the_most experts most_according_to .
 
-Zidane , Henry , Barthez , Deschamps , Blanc eta enparauek Europako talde sendoena osatzen dute aditu gehienentzat .
 punct(Henry-3, ,-2)
 conj(Zidane-1, Henry-3)
 punct(Barthez-5, ,-4)
@@ -54,7 +53,7 @@ Full stop is linked to the head of the sentence.
 ***The change** has caused a huge discussion .*
 
 ~~~ sdparse
-Eztabaida handia sortu du aldaketak .\n Discussion huge_a caused has change_the .
+Eztabaida handia sortu du aldaketak . \n Discussion huge_a caused has change_the .
 
 amod(Eztabaida-1, handia-2)
 nobj(sortu-3, Eztabaida-1)

--- a/_eu/dep/vocative.md
+++ b/_eu/dep/vocative.md
@@ -12,7 +12,7 @@ The `vocative` relation is used to mark dialogue participant addressed in text (
 ***Ganix**, come !*
 
 ~~~ sdparse
-Ganix, etorri! \n Ganix, come!
+Ganix , etorri ! \n Ganix , come !
 
 vocative(etorri-3, Ganix-1)
 punct(etorri-3, ,-2)
@@ -25,7 +25,7 @@ punct(etorri-3, !-4)
 *Where are you going, **Kurt** ?*
 
 ~~~ sdparse
-Nora zoaz, Kurt ? \n Where you_are_going, Kurt ?
+Nora zoaz , Kurt ? \n Where you_are_going , Kurt ?
 
 vocative(zoaz-2, Kurt-4)
 punct(zoaz-2, ,-3)

--- a/_eu/dep/xcomp.md
+++ b/_eu/dep/xcomp.md
@@ -13,14 +13,14 @@ These clauses are non-finite in Basque (although in some languages can be finite
 *Yesterday (he/she) decided **to leave** the training .*
 
 ~~~ sdparse
-Atzo entrenamendua uztea erabaki zuen .\n  Yesterday training_the to_leave decided .
+Atzo entrenamendua uztea erabaki zuen . \n  Yesterday training_the to_leave decided .
 
 advmod(erabaki-4, Atzo-1)
 obj(uztea-3, entrenamendua-2)
 xcomp(erabaki-4, uztea-3)
 aux(erabaki-4, zuen-5)
 punct(erabaki-4, .-6)
-~~~ sdparse
+~~~
 
 
 *Alkateek nahi dute lehenbailehen **biltzea** .*
@@ -28,12 +28,13 @@ punct(erabaki-4, .-6)
 *Mayors want **to meet** as soon as possible .*
 
 ~~~ sdparse
-Alkateek nahi dute lehenbailehen biltzea .\n  Mayors want as_soon_as_possible to_meet.
+Alkateek nahi dute lehenbailehen biltzea . \n  Mayors want as_soon_as_possible to_meet .
 
-nsubj(nahi_dute-2, Alkateek-1)
-xcomp(nahi_dute-2, biltzea-4)
-advmod(biltzea-4, lehenbailehen-3)
-punct(nahi_dute-2, .-5)
+nsubj(dute-3, Alkateek-1)
+compound(dute-3, nahi-2)
+xcomp(dute-3, biltzea-5)
+advmod(biltzea-5, lehenbailehen-4)
+punct(dute-3, .-6)
 ~~~
 
 
@@ -42,7 +43,7 @@ punct(nahi_dute-2, .-5)
 *I have seen them mentally **firm** .*
 
 ~~~ sdparse
-Mentalki irmo ikusi ditut haiek .\n Mentally firm seen have them .
+Mentalki irmo ikusi ditut haiek . \n Mentally firm seen have them .
 
 advmod(ikusi-3, Mentalki-1)
 xcomp(ikusi-3, irmo-2)
@@ -52,13 +53,12 @@ punct(ikusi-3, .-6)
 ~~~
 
 
-
 *Madrilera ez **joatea** erabaki zuen .*
 
 *(He/she) decided not **to go** to Madrid .*
 
 ~~~ sdparse
-Madrilera ez joatea erabaki zuen .\n  Madrid_to not to_go decided .
+Madrilera ez joatea erabaki zuen . \n  Madrid_to not to_go decided .
 
 nmod(joatea-3, Madrilera-1)
 advmod(joatea-3, ez-2)


### PR DESCRIPTION
Basque dependencies documentation had some typos, wrongly annotated examples and some brat rendering issues. This PR solves them all.