### PR TITLE
fix links to treebanks in _es documentation

### DIFF
--- a/_es/index.md
+++ b/_es/index.md
@@ -144,6 +144,6 @@ udver: '2'
 
 There are [three](../../treebanks/es-comparison.html) Spanish UD treebanks:
 
-  * [Spanish](../../treebanks/es-index.html)
-  * [Spanish-AnCora](../../treebanks/es_ancora-index.html)
-  * [Spanish-PUD](../../treebanks/es_pud-index.html)
+  * [Spanish](../../treebanks/es_gsd/index.html)
+  * [Spanish-AnCora](../../treebanks/es_ancora/index.html)
+  * [Spanish-PUD](../../treebanks/es_pud/index.html)

--- a/_es/index.md
+++ b/_es/index.md
@@ -144,6 +144,6 @@ udver: '2'
 
 There are [three](../../treebanks/es-comparison.html) Spanish UD treebanks:
 
-  * [Spanish](../../treebanks/es_gsd/index.html)
+  * [Spanish-GSD](../../treebanks/es_gsd/index.html)
   * [Spanish-AnCora](../../treebanks/es_ancora/index.html)
   * [Spanish-PUD](../../treebanks/es_pud/index.html)


### PR DESCRIPTION
Hi!
The links at the end of the Spanish documentation were broken. The name of the first treebank was missing in the link (GDS). This PR fixes both issues.
Thanks!