### PR TITLE
Typo: `passsive` -> `passive`

### DIFF
--- a/_en/feat/Voice.md
+++ b/_en/feat/Voice.md
@@ -7,7 +7,7 @@ udver: '2'
 
 In English, `Voice` is a feature of some [verbs](en-pos/VERB). It is only used to distinguish past participles from passive verbs which both have the PTB tag `VBN`.
 
-### <a name="Pass">`Pass`</a>: passsive
+### <a name="Pass">`Pass`</a>: passive
 
 All verbs with the PTB tag `VBN` that have a [passive auxiliary](en-dep/auxpass) have this feature.
 


### PR DESCRIPTION
Hello!

The title should speak for itself.

- Tom Aarsen