### PR TITLE
Exemplify word delimitation through Japanese

### DIFF
--- a/workgroups/newdoc/word_segmentation.md
+++ b/workgroups/newdoc/word_segmentation.md
@@ -83,6 +83,8 @@ Word segmentation with multi-word tokens should not be overused. It makes proces
 
 A good example is the contraction of a preposition and an article, as observed e.g. in German or many Romance languages: [de] _am = an + dem, zur = zu + der,_ [es] _al = a + el._ While they may have a specialized POS tag in the native POS tagsets, UPOS tags cannot account for each contraction type in each language, so we have to split such contractions to two words, tagged [ADP]() and [DET]().
 
+Another example involves particles, affixes, or clitics in agglutinative languages like Japanese: _やめれば = やめれ + ば._ Such languages may lack (e.g., Japanese) or have inconsistent (e.g., Old Turkish ":" separator) orthographic word delimiters. In the context of Japanese, the preferred split in UD separates _やめれ_ into VERB and _<b>ば</b>_ into SCONJ, producing a closed class for SCONJ, i.e., having an enumerable number of SCONJ lemmas independent of the set size of NOUN or VERB tags (contrast making such cases a morphological feature: SCONJ tag would be absent). By splitting, we allow covering more UPOS tags and deeper syntax trees for cross-linguistic alignment without violating open-closed categories, even without standard syntactic word delimitation.
+
 * If the split would result in syntactic words that also occur independently in the language, split it.
 
 Looking again at the preposition-article contractions in German, we note that elsewhere prepositions and articles are spelled as independent words: _<b>an</b> einem See_ “at a lake”, _nach <b>dem</b> Konzert_ “after the concert” etc.


### PR DESCRIPTION
Closes https://github.com/UniversalDependencies/docs/issues/946

I would like to kindly PR the addition of a paragraph to the new tokenization and segmentation document, which aims to illustrate the challenges associated with identifying word boundaries in languages with complex morphological structures, such as agglutinative languages where boundaries can be problematic regarding promoting dependent morphemes into syntactic words. I am eager to receive feedback and will promptly make revisions if prompted to ensure the text balances clarity and intricacy.

> Another example involves particles, affixes, or clitics in agglutinative languages like Japanese: _やめれば = やめれ + ば._ Such languages may lack (e.g., Japanese) or have inconsistent (e.g., Old Turkish ":" separator) orthographic word delimiters. In the context of Japanese, the preferred split in UD separates _やめれ_ into VERB and _<b>ば</b>_ into SCONJ, producing a closed class for SCONJ, i.e., having an enumerable number of SCONJ lemmas independent of the set size of NOUN or VERB tags (contrast making such cases a morphological feature: SCONJ tag would be absent). By splitting, we allow covering more UPOS tags and deeper syntax trees for cross-linguistic alignment without violating open-closed categories, even without standard syntactic word delimitation.

Although some might perceive the proposed short paragraph as a redundant and verbose addition, I firmly believe that including this example is essential for helping readers to understand better the intricacies found in agglutinative languages, particularly those who may not have training in linguistics terminology in the English language, highlighting the critical importance of recognizing open-closed category distinctions, otherwise easily overlooked but is vital for a comprehensive understanding of the topic for a correct evaluation.

Last but not least, this exemplification reflects the status quo as found directly in a language with a well-working instance of this, and the document is already about giving a helping hand to people for ease of understanding. I would really appreciate the support to incorporate this addition as a person who had a lot of learning from the Universal Dependencies project.