### PR TITLE
zh/PRON: add PronType=Ind/Int

### DIFF
--- a/_zh/feat/PronType.md
+++ b/_zh/feat/PronType.md
@@ -1,0 +1,27 @@
+---
+layout: feature
+title: 'PronType'
+shortdef: 'pronoun type'
+udver: '2'
+---
+
+`PronType` is a feature of [pronouns](PRON). It helps differenciating between wh-questions (`PronType=Int`) and wh-indefinite (`PronType=Ind`) pronouns.
+
+### <a name="Int">`Int`</a>: Interrogative
+
+Interrogative pronouns used for asking a question. The question can be direct or embedded.
+
+#### Examples
+
+* 你想吃<b>什麼</b>？ / _Nǐ xiǎng chī <b>shénme</b>?_ “What do you want to eat?”
+* 你想吃<b>什麼</b>我都不知道。/ _Nǐ xiǎng chī <b>shénme</b> wǒ dōu bù zhīdào。_ “I don't know what you want to eat.”
+
+### <a name="Ind">`Ind`</a>: Indefinite
+
+In concordance with the polarity 嗎 particle, with the NEG polarity markers 不/没 or some other particular constructions, these wh-word become indefinite pronouns.
+
+#### Examples
+
+* 你想吃<b>什麼</b>嗎？ / _Nǐ xiǎng chī <b>shénme</b> ma?_ “Do you want to eat anything?”
+
+


### PR DESCRIPTION
Hi everyone,

Our team in Paris Nanterre University (Modyco laboratory) is working on a SUD Mandarin treebank ([link here](https://github.com/surfacesyntacticud/mSUD_Chinese-Beginner)). Altough we only annotated 60% of the treebank, we started working on the automatic grew conversion rules ([written here](https://github.com/surfacesyntacticud/tools/blob/master/converter/grs/zh_SUD_to_UD.grs)) in prevision of the next UD release at the end of the month.

In our treebank, we were annotating both wh-question words and wh-indefinite words as `PRON` with a `PronType` feat of `Int` or `Ind`. 
This annotation is different from what has been done in the UD_Chinese-HK treebank, as the indefinite pronouns were annotated as `DET`.

We think the UD Mandarin treebank would benefit from this annotation as it would help queries based on the PronType.

We are willing to listen to any advice on the situation.


PS : as a sidenote, in the UD_Chinese-HK treebank, we can find some errors of annotation for these wh-question/wh-indefinite. If we follow the current UD Mandarin guidelines, we can still find, thanks to [this grew cluster query ](https://universal.grew.fr/?custom=652fe8b32e5a7) some inconsistencies. Indeed, some wh-question words were annotated as DET (wh-indefinite) ([for instance this sentence](https://gmb-9090.grew.fr/data/652fe8b32e5a7/55_0.svg)), it occurs for around 50% of the 23 annotated wh-indefinite. We can help to correct these.