### PR TITLE
Fix egy and he language index treebanks sections

### DIFF
--- a/_egy/index.md
+++ b/_egy/index.md
@@ -182,7 +182,7 @@ Marker ([mark](https://universaldependencies.org/u/dep/mark.html)):
 
 ## Treebanks
 
-There is [1](../treebanks/egy-comparison.html) Egyptian UD treebank:
+There is a single Egyptian UD treebank:
 
   * [Egyptian-UJaen](../treebanks/egy_ujaen/index.html)
 

--- a/_egy/index.md
+++ b/_egy/index.md
@@ -184,5 +184,5 @@ Marker ([mark](https://universaldependencies.org/u/dep/mark.html)):
 
 There is [1](../treebanks/egy-comparison.html) Egyptian UD treebank:
 
-  * [Egyptian-UJaen](../treebanks/egy_a/index.html)
+  * [Egyptian-UJaen](../treebanks/egy_ujaen/index.html)
 

--- a/_he/index.md
+++ b/_he/index.md
@@ -112,6 +112,6 @@ Non-verbal Clauses
 
 ## Treebanks
 
-Currently, Hebrew has a single treebank:
+Currently, Hebrew has [2](../treebanks/he-comparison.html) treebanks:
 * [Hebrew HTB](../treebanks/he_htb/index.html)
 * [Hebrew IAHLT](../treebanks/he_iahltwiki/index.html)

--- a/_he/index.md
+++ b/_he/index.md
@@ -113,5 +113,5 @@ Non-verbal Clauses
 ## Treebanks
 
 Currently, Hebrew has a single treebank:
-* [Hebrew HTB](http://universaldependencies.org/treebanks/he_htb/index.html)
-
+* [Hebrew HTB](../treebanks/he_htb/index.html)
+* [Hebrew IAHLT](../treebanks/he_iahltwiki/index.html)


### PR DESCRIPTION
Added the IAHLT link to the He language index, made the HTB link relative
Linked the He-comparison in the treebank section
Fixed the Egy treebank link, and removed non-existent comparison

- [x]  Local testing and screenshots
![Screenshot 2024-05-24 at 11-55-09 Hebrew UD](https://github.com/UniversalDependencies/docs/assets/9880628/542dc382-25c8-465c-9391-bf94641a79e6)
![Screenshot 2024-05-24 at 11-52-03 Egyptian UD](https://github.com/UniversalDependencies/docs/assets/9880628/e9bb62b4-7fbf-4260-ba79-2bf7a431a5b7)

resolves #1033
