### PR TITLE
Fix treebank links and comparison in egy and he pages

### DIFF
--- a/_egy/index.md
+++ b/_egy/index.md
@@ -182,7 +182,7 @@ Marker ([mark](https://universaldependencies.org/u/dep/mark.html)):
 
 ## Treebanks
 
-There is [1](../treebanks/egy-comparison.html) Egyptian UD treebank:
+There is a single Egyptian UD treebank:
 
-  * [Egyptian-UJaen](../treebanks/egy_a/index.html)
+  * [Egyptian-UJaen](../treebanks/egy_ujaen/index.html)
 

--- a/_he/index.md
+++ b/_he/index.md
@@ -112,6 +112,7 @@ Non-verbal Clauses
 
 ## Treebanks
 
-Currently, Hebrew has a single treebank:
-* [Hebrew HTB](http://universaldependencies.org/treebanks/he_htb/index.html)
+Currently, Hebrew has [2](../treebanks/he-comparison.html) treebanks:
+* [Hebrew HTB](../treebanks/he_htb/index.html)
+* [Hebrew IAHLT](../treebanks/he_iahltwiki/index.html)
 


### PR DESCRIPTION
Re-PR for 

egy language index page
Corrected link for egy treebank
Removed invalid comparison sublink in egy page

he language index page
Added IAHLT treebank to the he page
Added existing comparison page link to page

![Screenshot 2024-05-31 at 22-39-13 Egyptian UD](https://github.com/UniversalDependencies/docs/assets/9880628/2f84e197-5e06-49ac-ae5a-1fa675a10321)

![Screenshot 2024-05-31 at 22-39-33 Hebrew UD](https://github.com/UniversalDependencies/docs/assets/9880628/136e0c0d-b464-4aa0-9931-9c423fd8dabb)

resolves #1033
