### PR TITLE
Document obl:agent for English passives

### DIFF
--- a/_en/dep/aux-pass.md
+++ b/_en/dep/aux-pass.md
@@ -6,7 +6,7 @@ udver: '2'
 ---
 
 A passive auxiliary of a clause is a non-main verb of the clause which
-contains the passive information.
+marks it as passive. See: [English passive construction](../feat/Voice.html#pass-passive)
 
 ~~~ sdparse
 Kennedy has been killed

--- a/_en/dep/csubj-pass.md
+++ b/_en/dep/csubj-pass.md
@@ -5,8 +5,9 @@ shortdef : 'clausal passive subject'
 udver: '2'
 ---
 
-A clausal passive subject is a clausal syntactic subject of a passive
-clause. In the example below, *that she lied* is the subject.
+A clausal passive subject is a clausal syntactic subject of a 
+[passive clause](../feat/Voice.html#pass-passive).
+In the example below, *that she lied* is the subject.
 
 ~~~ sdparse
 That she lied was suspected by everyone

--- a/_en/dep/nsubj-pass.md
+++ b/_en/dep/nsubj-pass.md
@@ -6,10 +6,11 @@ udver: '2'
 ---
 
 A passive nominal subject is a noun phrase which is the syntactic
-subject of a passive clause.
+subject of a [passive clause](../feat/Voice.html#pass-passive).
 
 ~~~ sdparse
 Dole was defeated by Clinton
 nsubj:pass(defeated, Dole)
 ~~~
+
 <!-- Interlanguage links updated Po 11. listopadu 2024, 20:11:10 CET -->

--- a/_en/dep/obl-agent.md
+++ b/_en/dep/obl-agent.md
@@ -1,0 +1,24 @@
+---
+layout: relation
+title: 'obl:agent'
+shortdef: 'oblique nominal agent of the passive construction'
+udver: '2'
+---
+
+This subtype of [obl]() is recommended for the agent (or proto-agent) of a passive verb when realized as an oblique nominal (*by*-PP) in the [passive construction](../feat/Voice.html#pass-passive):
+
+~~~ sdparse
+The cat was chased by the dog
+nsubj:pass(chased, cat)
+obl:agent(chased, dog)
+case(dog, by)
+~~~
+
+~~~ sdparse
+We were delighted by the snow
+nsubj:pass(delighted, We)
+obl:agent(delighted, snow)
+case(snow, by)
+~~~
+
+<!-- Interlanguage links updated Po 11. listopadu 2024, 20:11:15 CET -->

--- a/_en/dep/obl.md
+++ b/_en/dep/obl.md
@@ -54,12 +54,12 @@ obl(give, children)
 case(children, to)
 ~~~
 
-`obl` is also used for the agent of a passive verb:
+`obl` is also used for the agent of a passive verb. Some treebanks distinguish the subtype [obl:agent]():
 
 ~~~ sdparse
 The cat was chased by the dog
 nsubj:pass(chased, cat)
-obl(chased, dog)
+obl:agent(chased, dog)
 case(dog, by)
 ~~~
 

--- a/_en/feat/VerbForm.md
+++ b/_en/feat/VerbForm.md
@@ -26,7 +26,7 @@ Infinitive is the citation form of verbs in many languages. Infinitives may be u
 
 ### <a name="Part">`Part`</a>: participle
 
-Participle is a non-finite verb form that shares properties of verbs and adjectives. It is used to form various periphrastic verb forms such as complex tenses and passives. In English, all words with the PTB tag `VBD` have this feature. Further, words with the PTB tag `VBG` can also have this feature (along with [Tense]()`=Pres`) if they are used in the progressive construction (with an [aux]()), or otherwise occur in non-noun-like environments.[^1]
+Participle is a non-finite verb form that shares properties of verbs and adjectives. It is used to form various periphrastic verb forms such as complex tenses and [passives](Voice.html#pass-passive). In English, all words with the PTB tag `VBD` have this feature. Further, words with the PTB tag `VBG` can also have this feature (along with [Tense]()`=Pres`) if they are used in the progressive construction (with an [aux]()), or otherwise occur in non-noun-like environments.[^1]
 
 [^1]: The `VBG` policy was refined for the v2.14 release and implemented in GUM and EWT per the rules detailed [here](https://github.com/UniversalDependencies/UD_English-EWT/issues/305). (Coordination adds some complexity to the rules as it needs to be determined whether it is a noun-like coordination.)
 

--- a/_includes/en-dep-table.html
+++ b/_includes/en-dep-table.html
@@ -48,8 +48,11 @@
 	  <td><a>advmod</a></td>
 	</tr>
 	<tr>
-	  <td>↳<a>obl:unmarked</a></td>
+	  <td>↳<a>obl:agent</a></td>
 	  <td>↳<a>advcl:relcl</a></td>
+	</tr>
+	<tr>
+	  <td>↳<a>obl:unmarked</a></td>
 	</tr>
       </table>
 

--- a/_u-dep/aux_.md
+++ b/_u-dep/aux_.md
@@ -14,7 +14,7 @@ expresses categories such as tense, mood, aspect, voice or evidentiality. It is 
 are also treated as instances of `aux`. 
 
 **New from v2:** Auxiliares used to construct the passive [voice](u-feat/Voice) are now also labeled `aux`,
-although we strongly encourage the use of the subtype `aux:pass` in language that have a grammaticalized (periphrastic)
+although we strongly encourage the use of the subtype [aux:pass]() in language that have a grammaticalized (periphrastic)
 passive. 
 
 ~~~ sdparse

--- a/_u-dep/aux_.md
+++ b/_u-dep/aux_.md
@@ -13,7 +13,7 @@ expresses categories such as tense, mood, aspect, voice or evidentiality. It is 
 (which may have non-auxiliary uses as well) but many languages have nonverbal TAME markers and these
 are also treated as instances of `aux`. 
 
-**New from v2:** Auxiliares used to construct the passive [voice](u-feat/Voice) are now also labeled `aux`,
+**New from v2:** Auxiliaries used to construct the passive [voice](u-feat/Voice) are now also labeled `aux`,
 although we strongly encourage the use of the subtype [aux:pass]() in language that have a grammaticalized (periphrastic)
 passive. 
 

--- a/_u-dep/aux_.md
+++ b/_u-dep/aux_.md
@@ -14,7 +14,7 @@ expresses categories such as tense, mood, aspect, voice or evidentiality. It is 
 are also treated as instances of `aux`. 
 
 **New from v2:** Auxiliaries used to construct the passive [voice](u-feat/Voice) are now also labeled `aux`,
-although we strongly encourage the use of the subtype [aux:pass]() in language that have a grammaticalized (periphrastic)
+although we strongly encourage the use of the subtype [aux:pass]() in languages that have a grammaticalized (periphrastic)
 passive. 
 
 ~~~ sdparse

--- a/_u-dep/obl-agent.md
+++ b/_u-dep/obl-agent.md
@@ -1,12 +1,23 @@
 ---
 layout: relation
 title:  'obl:agent'
-shortdef : 'agent modifier'
+shortdef : 'oblique agent in passive construction'
 udver: '2'
 ---
 
-The relation `obl:agent` is used for agents of passive verbs.
-In Czech, the agent is a nominal in the instrumental [Case]().
+The relation `obl:agent` is used for agents of passive verbs. It is a subtype of [obl](), which covers all oblique nominals.
+`obl:agent` is a [semi-mandatory subtype](/u/dep/), i.e. it should be used if the language has passives with oblique agents.
+
+In English, the agent is marked by the preposition *by*:
+
+~~~ sdparse
+The cat was chased by the dog
+nsubj:pass(chased, cat)
+obl:agent(chased, dog)
+case(dog, by)
+~~~
+
+In Czech, the agent is a nominal in the instrumental [Case]():
 
 ~~~ sdparse
 Cena byla udělena děkanem fakulty . \n Prize was awarded by-dean of-faculty .
@@ -17,7 +28,7 @@ obl:agent(awarded, by-dean)
 Typical agents are animate but it is not a rule.
 Inanimate agents may be sometimes difficult to distinguish from instruments,
 which are also coded by the instrumental case.
-Instruments are attached using the simple relation `obl`.
+Instruments are attached using the simple relation [obl]().
 Consider the following two examples, the first one is active and the second is passive.
 
 ~~~ sdparse

--- a/_u-dep/obl.md
+++ b/_u-dep/obl.md
@@ -64,7 +64,7 @@ obl(swam, night)
 obl(swam, pool)
 ~~~
 
-and for the agent of a passive verb (with the optional subtype obl:agent):
+and for the agent of a passive verb (with the subtype [obl:agent]()):
 
 ~~~ sdparse
 the cat was chased by the dog

--- a/_u-feat/Voice.md
+++ b/_u-feat/Voice.md
@@ -77,7 +77,7 @@ The subject of the verb is affected by the action (patient). The doer
 or an object of the verb. This label is also used for the patient-focus
 voice of Austronesian languages. <!-- which is labeled PFOC in UniMorph -->
 Note the subtyped dependency relations [nsubj:pass](), [csubj:pass](),
-[expl:pass], and [aux:pass]() for analytic components of passive constructions.
+[expl:pass](), and [aux:pass]() for analytic components of passive constructions.
 
 #### Examples
 

--- a/_u-feat/Voice.md
+++ b/_u-feat/Voice.md
@@ -76,8 +76,8 @@ The subject of the verb is affected by the action (patient). The doer
 (agent) is either unexpressed or it appears as an oblique dependent
 or an object of the verb. This label is also used for the patient-focus
 voice of Austronesian languages. <!-- which is labeled PFOC in UniMorph -->
-Note the subtyped dependency relations [nsubj:pass](), [csubj:pass](), and [aux:pass]()
-for analytic components of passive constructions.
+Note the subtyped dependency relations [nsubj:pass](), [csubj:pass](),
+[expl:pass], and [aux:pass]() for analytic components of passive constructions.
 
 #### Examples
 

--- a/_u-feat/Voice.md
+++ b/_u-feat/Voice.md
@@ -76,6 +76,8 @@ The subject of the verb is affected by the action (patient). The doer
 (agent) is either unexpressed or it appears as an oblique dependent
 or an object of the verb. This label is also used for the patient-focus
 voice of Austronesian languages. <!-- which is labeled PFOC in UniMorph -->
+Note the subtyped dependency relations [nsubj:pass](), [csubj:pass](), and [aux:pass]()
+for analytic components of passive constructions.
 
 #### Examples
 

--- a/_u-overview/complex-syntax.md
+++ b/_u-overview/complex-syntax.md
@@ -140,7 +140,7 @@ In addition, we discuss _secondary predicates_, which are analyzed as clausal co
 ### Clausal Subjects
 
 A clausal subject is a clausal syntactic subject of a clause. Its governor may be a verb or a nonverbal predicate.
-If the governor is in the passive, the subtype `csubj:pass` can be used.
+If the governor is in the passive, the subtype [csubj:pass]() is strongly recommended.
 
 ~~~ sdparse
 Eating meals at regular times can improve digestion

--- a/_u-overview/simple-syntax.md
+++ b/_u-overview/simple-syntax.md
@@ -61,7 +61,7 @@ Note, finally, that not all languages allow extended transitives (and some do on
 
 If passivization involves the promotion of an argument to subject position, then this argument can be
 annotated with a special subtype `nsubj:pass` to indicate that promotion has taken place. The subtype
-`obl:agent` can be used to annotate the demoted subject (if present).
+[obl:agent]() can be used to annotate the demoted subject (if present).
 
 ~~~ sdparse
 she left a note on the table

--- a/_u-overview/simple-syntax.md
+++ b/_u-overview/simple-syntax.md
@@ -61,7 +61,7 @@ Note, finally, that not all languages allow extended transitives (and some do on
 
 If passivization involves the promotion of an argument to subject position, then this argument can be
 annotated with a special subtype `nsubj:pass` to indicate that promotion has taken place. The subtype
-[obl:agent]() can be used to annotate the demoted subject (if present).
+[obl:agent]() indicates the demoted subject (if present).
 
 ~~~ sdparse
 she left a note on the table


### PR DESCRIPTION
Per https://github.com/UniversalDependencies/UD_English-EWT/issues/290, English treebanks have been adopting `obl:agent`. This PR adds it to the English docs.