### PR TITLE
Update Person.md

### DIFF
--- a/_pt/feat/Person.md
+++ b/_pt/feat/Person.md
@@ -11,6 +11,15 @@ fact an agreement feature that marks the person of the verb's subject. Person
 marked on verbs makes it unnecessary to always add a personal pronoun
 as subject and thus subjects are sometimes dropped (pro-drop
 languages).
+### <a name="0">`0`</a>:  impersonal
+
+The impersonal value is used to annotate both finite and infinite verbal forms that do not accept a subject even in enhanced dependencies. 
+
+#### Examples
+* <b>Faz</b> tempo que ninguém vem aqui.
+* <b>Havia</b> sinais de deterioração.
+* <b>Considerando</b> tudo isso, você deveria desistir. 
+* Ela sugere <b>entrar</b> em contato por telefone. 
 
 ### <a name="1">`1`</a>: first person
 
@@ -20,7 +29,10 @@ persons.
 
 #### Examples
 
-* _<b>eu</b>_, _<b>nós</b>_
+* <b>eu</b>, <b>nós</b>
+* <b>meu</b>, <b>nossas</b>
+* <b>me</b>, <b>nos</b>
+* <b>mim</b>
 * <b>quero</b>, <b>queremos</b>
 
 ### <a name="2">`2`</a>: second person
@@ -31,8 +43,11 @@ optionally some third persons too.
 
 #### Examples
 
-* _<b>tu, você, vós, vocês</b>_
-* _<b>queres, quereis</b>_
+* <b>tu, você, vós, vocês</b>
+* <b>teu</b>, <b>vossas</b>
+* <b>te</b>, <b>vos</b>
+* <b>ti</b>
+* <b>queres, quereis</b>
 
 ### <a name="3">`3`</a>: third person
 
@@ -41,7 +56,9 @@ speakers nor addressees.
 
 #### Examples
 
-* _<b>ele, ela, eles, elas</b>_
-* _<b>quer, querem</b>_
-
+* <b>ele, ela, eles, elas</b>
+* <b>seu</b>, <b>suas</b>
+* <b>se</b>
+* <b>si</b>
+* <b>quer, querem</b>
 <!-- Interlanguage links updated Po 11. listopadu 2024, 20:09:56 CET -->


### PR DESCRIPTION
There are impersonal verbs and impersonal use of personal verbs that need to be annotated in Portuguese to prevent parsers from assigning them a subject.

I've taken the opportunity to include examples of possessive, oblique and dative pronouns for Person 1, 2 and 3.