### PR TITLE
Old English obl:unmarked

### DIFF
--- a/_ang/dep/obl-unmarked.html
+++ b/_ang/dep/obl-unmarked.html
@@ -1,0 +1,22 @@
+---
+layout: relation
+title: 'obl:unmarked'
+shortdef : 'adpositionless oblique'
+udver: '2'
+---
+
+This relation is a subtype of the obl relation that applies
+when an oblique takes the form of a nominal lacking a preposition
+(a.k.a. a noun phrase). It is "unmarked" in that, unlike most obliques,
+it has no adposition.
+
+Examples include:
+
+~~~ sdparse
+Þis ærend-ƿrit is fram Petere and hit ƿæs ȝebroht ȝierstan-dæg .\n This letter is from Peter and it was brought yesterday.
+obl:unmarked(ȝebroht, ȝierstan-dæg)
+~~~
+
+This page has been adopted from its English counterpart.
+
+<!-- Interlanguage links updated Po 11. listopadu 2024, 20:11:22 CET -->


### PR DESCRIPTION
Add Old English obl:unmarked, similar to its modern equivalent.

E.g. Þis ærend-ƿrit is fram Petere and hit ƿæs ȝebroht ȝierstan-dæg.
This letter is from Peter and it was brought yesterday

Here, ȝierstan-dæg has an obl:unmarked relation that points to ȝebroht.