### PR TITLE
Document amod:poss for Italian

### DIFF
--- a/_it/dep/amod-pos.md
+++ b/_it/dep/amod-pos.md
@@ -1,0 +1,20 @@
+---
+layout: relation
+title: 'amod:pos'
+shortdef: 'possessive adjectival modifier'
+udver: '2'
+---
+
+Whenever there is a possessive adjectival modifier, <code>amod:poss</code> should be used instead of <code>amod</code>. All possessive adjectives have the feature <code>Possessive</code> defined as <code>Yes</code> and the only instances of the <code>amod:poss</code> relation attested in the Italian Treebank appear with those elements.
+
+~~~ sdparse
+Lui è un mio amico .
+det:poss(amico, mio)
+~~~
+
+~~~ sdparse
+Il lavoro vostro , invece , in cosa consiste ?
+det:poss(lavoro, vostro)
+~~~
+
+<!-- Interlanguage links updated So 10. května 2025, 18:14:57 CEST -->

--- a/_it/dep/amod-poss.md
+++ b/_it/dep/amod-poss.md
@@ -1,6 +1,6 @@
 ---
 layout: relation
-title: 'amod:pos'
+title: 'amod:poss'
 shortdef: 'possessive adjectival modifier'
 udver: '2'
 ---
@@ -9,12 +9,12 @@ Whenever there is a possessive adjectival modifier, <code>amod:poss</code> shoul
 
 ~~~ sdparse
 Lui è un mio amico .
-det:poss(amico, mio)
+amod:poss(amico, mio)
 ~~~
 
 ~~~ sdparse
 Il lavoro vostro , invece , in cosa consiste ?
-det:poss(lavoro, vostro)
+amod:poss(lavoro, vostro)
 ~~~
 
 <!-- Interlanguage links updated So 10. května 2025, 18:14:57 CEST -->


### PR DESCRIPTION
During work on spoken Italian, we introduced `amod:poss` for cases of possessive modifiers, formerly only tagged as `det:poss` (`mio`, `tuo`, `suo`, etc.), when they do not occupy the determiner slot.
Especially (but not exclusively) in spoken Italian, the analysis as `det:poss` is not satisfactory as they can also appear after the noun, while determiners can only precede the noun in Italian.
This PR adds it to the Italian docs.