### PR TITLE
`nmod:unmarked` for Swedish

### DIFF
--- a/_sv/dep/nmod-unmarked.md
+++ b/_sv/dep/nmod-unmarked.md
@@ -1,0 +1,20 @@
+---
+layout: relation
+title: 'nmod:unmarked'
+shortdef : 'unmarked nominal modifier'
+udver: '2'
+---
+
+This relation is a subtype of the [nmod]() relation that applies
+when a non-possessive modifier within a nominal takes the form of a 
+nominal lacking a preposition (a.k.a. a noun phrase). It is 
+"unmarked" in that, unlike most `nmod`s, it has no adposition or
+genitive marking.
+
+`nmod:unmarked` merges two older subtypes, `nmod:npmod` (noun phrase as 
+adverbial modifier) and `nmod:tmod` (temporal modifier) (not attested in the
+Swedish treebanks).
+
+`nmod:unmarked` has a clause-level countepart: [obl:unmarked]().
+
+<!-- Interlanguage links updated So 10. května 2025, 18:15:46 CEST -->


### PR DESCRIPTION
In the upcoming SweLL treebank, we have a handful of sentences with citations such as

> I artikeln " Tre röster om svenskan ställning i Finland " __( Parnass , 2013:3 )__ skriver Catharina Söderbergh om tre personer som har sagt sin åsikt om tvångssvenskan och hur svenskan befinner sig .

Looking through old issues, I found that some (English) treebanks used to annotate these as `nmod:tmod`(Parnass, 2013), but I then saw that that subtype has been replaced by `nmod:unmarked`. This is my immediate rationale for proposing this addition.

Another reason to add `nmod:unmarked` for Swedish is comparability: [the English half of LinES already uses it](https://universal.grew.fr/?custom=69048926b0cf3), often in cases where I think it would be relevant for Swedish too.

If this is too last minute for 2.17 and/or more controversial than I expect (the documentation page I added could be a bit too minimal too), it can of course wait.