### PR TITLE
Add "part" subtypes hebrew

### DIFF
--- a/_he/dep/advmod-part.md
+++ b/_he/dep/advmod-part.md
@@ -1,0 +1,38 @@
+---
+layout: relation
+title: 'advmod:part'
+shortdef: 'adverbial modifier of participle'
+udver: '2'
+---
+
+This relation is a subtype of the [advmod]() relation, which captures cases where the adverb is dependent on a participle that plays both nominal and verbal syntactic roles.
+
+<!-- Example 1 -->
+~~~ conllu
+# sent_id = 173
+# source = רשי_לתורה
+# text = מיד ההורג במזיד ואין עדים אני אדרוש
+# visual-style 4 5 advmod:part color:blue
+1-2	מיד	_	_	_	_	_	_	_	_
+1	מ	מ	ADP	ADP	_	2	case	_	_
+2	יד	יד	NOUN	NOUN	_	10	obl	_	_
+3-4	ההורג	_	_	_	_	_	_	_	_
+3	ה	ה	DET	DET	_	4	det	_	_
+4	הורג	הרג	VERB	VERB	Gender=Masc|Number=Sing|Person=1,2,3|VerbForm=Part	2	compound:smixut	_	_
+5	במזיד	במזיד	ADV	ADV	_	4	advmod:part	_	_
+6-7	ואין	_	_	_	_	_	_	_	_
+6	ו	ו	CCONJ	CCONJ	_	7	cc	_	_
+7	אין	אין	VERB	VERB	_	4	conj	_	_
+8	עדים	עד	NOUN	NOUN	Gender=Masc|Number=Plur	7	nsubj	_	_
+9	אני	הוא	PRON	PRON	Gender=Fem,Masc|Number=Sing|Person=1	10	nsubj	_	_
+10	אדרוש	דרש	VERB	VERB	Gender=Fem,Masc|Number=Sing|Person=1|Tense=Fut	0	root	_	_
+~~~
+
+_Mi-yad ha-horeg be-mezid ṿe-en ʻedim ani edrosh_
+
+"From the hand of one who <b>kills intentionally</b> (lit. _the killer intentionally_) and there are no witnesses, I will demand."
+
+The participle הורג is the second element of a nominal [compound:smixut]() construct, but has a clearly verbal complement in the adverb במזיד.
+
+See also [obj:part]() and [obl:part]().
+

--- a/_he/dep/obj-part.md
+++ b/_he/dep/obj-part.md
@@ -1,0 +1,50 @@
+---
+layout: relation
+title: "obj:part"
+shortdef: "object of participle"
+udver: "2"
+---
+
+This relation is a subtype of the [obj]() relation, which captures cases where a word is the object of a participle that plays both nominal and verbal syntactic roles.
+
+<!-- Example 1 -->
+
+~~~ conllu
+# sent_id = 172
+# source = רשי_לתורה
+# text = אף על פי שהתרתי לכם נטילת נשמה בבהמה את דמכם אדרוש מהשופך דם עצמו
+# visual-style 18 19 obj:part color:blue
+1	אף	אף	ADV	ADV	_	5	mark	_	_
+2	על	על	ADP	ADP	_	1	fixed	_	_
+3	פי	פה	NOUN	NOUN	_	1	fixed	_	_
+4-5	שהתרתי	_	_	_	_	_	_	_	_
+4	ש	ש	SCONJ	SCONJ	_	1	fixed	_	_
+5	התרתי	התיר	VERB	VERB	Gender=Fem,Masc|Number=Sing|Person=1|Tense=Past	15	advcl	_	_
+6-7	לכם	_	_	_	_	_	_	_	_
+6	ל	ל	ADP	ADP	_	7	case	_	_
+7	כם	הוא	PRON	PRON	Gender=Masc|Number=Plur|Person=2	5	obl	_	_
+8	נטילת	נטילה	NOUN	NOUN	Gender=Fem|Number=Sing	5	obj	_	_
+9	נשמה	נשמה	NOUN	NOUN	Gender=Fem|Number=Sing	8	compound:smixut	_	_
+10-11	בבהמה	_	_	_	_	_	_	_	_
+10	ב	ב	ADP	ADP	_	11	case	_	_
+11	בהמה	בהמה	NOUN	NOUN	Gender=Fem|Number=Sing	8	nmod	_	_
+12	את	את	ADP	ADP	_	13	case	_	_
+13-14	דמכם	_	_	_	_	_	_	_	_
+13	דמ	דם	NOUN	NOUN	Gender=Masc|Number=Sing	15	obj	_	_
+14	כם	הוא	PRON	PRON	Gender=Masc|Number=Sing|Person=2	13	nmod:poss	_	_
+15	אדרוש	דרש	VERB	VERB	Gender=Fem,Masc|Number=Sing|Person=1|Tense=Fut	0	root	_	_
+16-18	מהשופך	_	_	_	_	_	_	_	_
+16	מ	מ	ADP	ADP	_	18	case	_	_
+17	ה	ה	DET	DET	_	18	det	_	_
+18	שופך	שפך	VERB	VERB	Gender=Masc|Number=Sing|Person=1,2,3|VerbForm=Part	15	obl	_	_
+19	דם	דם	NOUN	NOUN	Gender=Masc|Number=Sing	18	obj:part	_	_
+20	עצמו	עצמו	PRON	PRON	Reflex=Yes	19	compound:smixut	_	_
+~~~
+
+_Af ʻal pi she-hitarti lakhem neṭilat neshamah bi-vehemah et dimkhem edrosh meha-shofekh dam ʻatsmo_
+
+"Although I permitted you the taking of a life with regard to animals, I will demand the blood of the <b>spiller</b> [of] his own blood."
+
+The participle שופך serves itself as an oblique adjunct of the verb אדרוש and has both a case marker and a definite article, but has a clearly verbal complement in its object, דם.
+
+See also [obl:part]() and [advmod:part]().

--- a/_he/dep/obl-part.md
+++ b/_he/dep/obl-part.md
@@ -1,0 +1,41 @@
+---
+layout: relation
+title: "obl:part"
+shortdef: "oblique adjunct of participle"
+udver: "2"
+---
+
+This relation is a subtype of the [obl]() relation, which captures cases where the oblique adjunct is dependent on a participle that plays both nominal and verbal syntactic roles.
+
+<!-- Example 1 -->
+
+~~~ conllu
+# sent_id = 119
+# source = ספר_החינוך
+# text = אשרי הזוכים אליה כי אז יקיימו מצוה זו על בוריה
+# visual-style 3 5 obl:part color:blue
+1	אשרי	אשרי	ADV	ADV	_	0	root	_	_
+2-3	הזוכים	_	_	_	_	_	_	_	_
+2	ה	ה	DET	DET	_	3	det	_	_
+3	זוכים	זוכה	VERB	VERB	Gender=Masc|Number=Plur|Person=1,2,3|VerbForm=Part	1	nsubj	_	_
+4-5	אליה	_	_	_	_	_	_	_	_
+4	אלי	אל	ADP	ADP	_	5	case	_	_
+5	ה	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3	3	obl:part	_	_
+6	כי	כי	SCONJ	SCONJ	_	8	mark	_	_
+7	אז	אז	ADV	ADV	_	8	advmod	_	_
+8	יקיימו	קיים	VERB	VERB	Gender=Fem,Masc|Number=Plur|Person=3|Tense=Fut	1	advcl	_	_
+9	מצוה	מצווה	NOUN	NOUN	Gender=Fem|Number=Sing	8	obj	_	_
+10	זו	זה	PRON	PRON	Gender=Fem|Number=Sing|Person=3	9	det	_	_
+11	על	על	ADP	ADP	_	12	case	_	_
+12-13	בוריה	_	_	_	_	_	_	_	_
+12	בורי	בורי	NOUN	NOUN	Gender=Masc|Number=Sing	8	obl	_	_
+13	ה	הוא	PRON	PRON	Gender=Fem|Number=Sing|Person=3	12	nmod:poss	_	_
+~~~
+
+_Ashre ha-zokhim eleha ki az yeḳayemu mitsṿah zo ʻal buryah_
+
+"Fortunate are the <b>meritors</b> of (lit. _to_) <b>it</b>, for they fulfill this commandment completely."
+
+The participle זוכים is the subject of the sentence and takes a definite article, but also has a clearly verbal complement in אליה.
+
+See also [obj:part]() and [advmod:part]().


### PR DESCRIPTION
Add `:part` subtypes for Hebrew, used with participles in forthcoming post-rabbinic Hebrew treebank