### PR TITLE
added examples for unattested and legacy categories

### DIFF
--- a/_gor/dep/obj-instrument.md
+++ b/_gor/dep/obj-instrument.md
@@ -7,6 +7,15 @@ udver: '2'
 
 `obj:instrument` is used for a nominal core argument of a verb that is in a non-pivot role and whose 
 semantic role is instrumental. Typically this will be signalled as a core argument by way of a 
-non-pivot marker. This is not currently attested but is documented here in 
+non-pivot marker. This is not currently attested in the treebnaks but is documented here in 
 anticipation.
 
+~~~ sdparse
+Uponula tilubu lo bulonggo \n fish cooked NPIV pan
+obj:instrument(tilubu, bulonggo)
+obj:instrument(cooked, pan)
+nsubj:patient(tilubu, Uponula)
+nsubj:patient(cooked, fish)
+~~~
+
+"\[someone\] cooked fish in the pan"

--- a/_gor/feat/Case.md
+++ b/_gor/feat/Case.md
@@ -53,8 +53,18 @@ The non-pivot marker may also be used to mark modifiers of other nominals, for e
 more directly descriptive of symmetrical voice, but we document `Nom` here so that `Piv` may be 
 losslessly converted to it for compatibility.
 
+#### Examples
+
+* [gor] _**Ti** Dewi lo-tubu uponula_ "Dewi cooked the fish." (actor voice)
+* [gor] _**Te** Hasan pilohama li Dewi batade_ "Dewi took the goat from Hasan" (instrument voice)
+* [gor] _**Te** Pulu londo Limutu_ "Pulu is from Limboto."
+
 ### <a name="Gen">`Gen`</a>: genitive
 
 `Gen` is used for non-pivot markers in most symmetrical voice languages in UD. We prefer `Npiv` as it is
 more directly descriptive of symmetrical voice, but we document `Gen` here so that `Npiv` may be 
 losslessly converted to it for compatibility.
+
+#### Examples
+* [gor] _Uponula tilubu **li** Dewi **lo** bulonggo_ "**(NPIV)** Dewi cooked fish **in** the pan." or "The pan was cooked fish **in** **by** Dewi"
+* [gor] _Te Pulu wutata **li** Ati_ "Pulu is the sibling **of** Ati."

--- a/_gor/feat/Voice.md
+++ b/_gor/feat/Voice.md
@@ -52,6 +52,10 @@ voice of Austronesian languages. <!-- which is labeled PFOC in UniMorph -->
 The `Pass` label is commonly used in UD Austronesian languages for patient voice markers.
 We do not use it in Gorontalo, but retain it for compatibility purposes.
 
+#### Examples
+
+* [gor] _Uponula **tilubu** li Dewi_ “Dewi cooked the fish." (patient voice) or "The fish was cooked by Dewi" (passive analysis)
+
 ### <a name="Ivoc">`Ivoc`</a>: instrument voice
 
 The subject of the verb indicates the instrument, while the
@@ -66,3 +70,7 @@ In Gorontalo, instrument voice multitasks as indicating the location of an actio
 
 The `Ifoc` label is commonly used in UD Austronesian languages for instrument voice markers.
 We do not use it in Gorontalo, preferring the __voc_ pattern that emphasises voice, but document it for compatibility purposes.
+
+#### Examples
+
+* [gor] _Ilengi pilo-pomulo li Bapu binthe_ “Grandfather planted corn in the field" (instrument voice)


### PR DESCRIPTION
Lack of examples for some defined feature values was leading to them being unable to be defined for validation. Added these missing values.