### PR TITLE
Fix aux redirection

### DIFF
--- a/_bej/dep/aux_.md
+++ b/_bej/dep/aux_.md
@@ -2,6 +2,9 @@
 layout: relation
 title: 'aux'
 shortdef: 'auxiliary'
+# The filename "aux" is not allowed on Windows, so we redirect instead
+# (see https://github.com/UniversalDependencies/docs/issues/20)
+redirect_from: "bej/dep/aux.html"
 udver: '2'
 ---
 

--- a/_de/dep/aux_.md
+++ b/_de/dep/aux_.md
@@ -3,6 +3,9 @@ udver: '2'
 layout: relation
 title: 'aux'
 shortdef: 'auxiliary'
+# The filename "aux" is not allowed on Windows, so we redirect instead
+# (see https://github.com/UniversalDependencies/docs/issues/20)
+redirect_from: "de/dep/aux.html"
 ---
 
 An `aux` (auxiliary) of a clause is a function word associated (a verb) with a verbal predicate that expresses categories such as tense, mood, aspect, voice or evidentiality. In German this includes verbs sein and haben when they indicate past tense, verb werden when it indicates future tense or a poosibility, as well as modal verbs. 

--- a/_gsw/dep/aux_.md
+++ b/_gsw/dep/aux_.md
@@ -3,6 +3,9 @@ udver: '2'
 layout: relation
 title: 'aux'
 shortdef: 'auxiliary'
+# The filename "aux" is not allowed on Windows, so we redirect instead
+# (see https://github.com/UniversalDependencies/docs/issues/20)
+redirect_from: "gsw/dep/aux.html"
 ---
 
 An `aux` (auxiliary) of a clause is a function word associated (a verb) with a verbal predicate that expresses categories such as tense, mood, aspect, voice or evidentiality. In German this includes verbs sein and haben when they indicate past tense, verb werden when it indicates future tense or a poosibility, as well as modal verbs. 

--- a/_gub/dep/aux_.md
+++ b/_gub/dep/aux_.md
@@ -2,6 +2,9 @@
 layout: relation
 title: 'aux'
 shortdef: 'auxiliary'
+# The filename "aux" is not allowed on Windows, so we redirect instead
+# (see https://github.com/UniversalDependencies/docs/issues/20)
+redirect_from: "gub/dep/aux.html"
 udver: '2'
 ---
 

--- a/_id/dep/aux_.md
+++ b/_id/dep/aux_.md
@@ -2,6 +2,9 @@
 layout: relation
 title: 'aux'
 shortdef: 'auxiliary'
+# The filename "aux" is not allowed on Windows, so we redirect instead
+# (see https://github.com/UniversalDependencies/docs/issues/20)
+redirect_from: "id/dep/aux.html"
 udver: '2'
 ---
 

--- a/_ja/dep/aux_.md
+++ b/_ja/dep/aux_.md
@@ -4,7 +4,7 @@ title: 'aux'
 shortdef: 'auxiliary'
 # The filename "aux" is not allowed on Windows, so we redirect instead
 # (see https://github.com/UniversalDependencies/docs/issues/20)
-redirect_from: "/ja/dep/_aux"
+redirect_from: "ja/dep/aux.html"
 udver: '2'
 ---
 

--- a/_ka/dep/aux_.md
+++ b/_ka/dep/aux_.md
@@ -3,6 +3,9 @@ udver: '2'
 layout: relation
 title: 'aux'
 shortdef: 'auxiliary'
+# The filename "aux" is not allowed on Windows, so we redirect instead
+# (see https://github.com/UniversalDependencies/docs/issues/20)
+redirect_from: "ka/dep/aux.html"
 ---
 
 An `aux` (auxiliary) of a clause is a function word associated (a verb) with a verbal predicate. In Georgian such kinds of constructions are generally discussed as part of composite predicates. E.g. 

--- a/_oge/dep/aux_.md
+++ b/_oge/dep/aux_.md
@@ -3,6 +3,9 @@ udver: '2'
 layout: relation
 title: 'aux'
 shortdef: 'auxiliary'
+# The filename "aux" is not allowed on Windows, so we redirect instead
+# (see https://github.com/UniversalDependencies/docs/issues/20)
+redirect_from: "oge/dep/aux.html"
 ---
 
 An `aux` (auxiliary) of a clause is a function word associated (a verb) with a verbal predicate. In Georgian such kinds of constructions are generally discussed as part of composite predicates. E.g. 

--- a/_qpm/dep/aux_.md
+++ b/_qpm/dep/aux_.md
@@ -3,6 +3,9 @@ udver: '2'
 layout: relation
 title: 'aux'
 shortdef: 'auxiliary'
+# The filename "aux" is not allowed on Windows, so we redirect instead
+# (see https://github.com/UniversalDependencies/docs/issues/20)
+redirect_from: "qpm/dep/aux.html"
 ---
 
 

--- a/_sl/dep/aux_.md
+++ b/_sl/dep/aux_.md
@@ -3,6 +3,9 @@ layout: relation
 title: 'aux'
 shortdef: 'auxiliary'
 udver: '2'
+# The filename "aux" is not allowed on Windows, so we redirect instead
+# (see https://github.com/UniversalDependencies/docs/issues/20)
+redirect_from: "sl/dep/aux.html"
 ---
 
 An auxiliary of a clause is a function word associated with a verbal predicate that expresses categories such as tense, mood, aspect, voice or evidentiality. In contrast to the languages and grammatical theories that also categorize other function words as auxiliaries, the `aux` relation in Slovene is used exclusively for the auxiliary verb **biti** (_to be_), e.g. to form non-present tense. 

--- a/_ssp/dep/aux_.md
+++ b/_ssp/dep/aux_.md
@@ -4,6 +4,7 @@ title: 'aux'
 shortdef: 'auxiliary'
 # The filename "aux" is not allowed on Windows, so we redirect instead
 # (see https://github.com/UniversalDependencies/docs/issues/20)
+redirect_from: "ssp/dep/aux.html"
 udver: '2'
 ---
 

--- a/_urj/dep/aux_.md
+++ b/_urj/dep/aux_.md
@@ -4,7 +4,7 @@ title: 'aux'
 shortdef : 'auxiliary'
 # The filename "aux" is not allowed on Windows, so we redirect instead
 # (see https://github.com/UniversalDependencies/docs/issues/20)
-redirect_from: "fi/dep/aux.html"
+redirect_from: "urj/dep/aux.html"
 udver: '2'
 ---
 


### PR DESCRIPTION
Navigating to the `aux` dep page for some languages results in a 404. This is just a small PR to add the appropriate redirection links to the frontmatter of those pages, which should fix the issue. Thanks for working on UD!