### PR TITLE
Add documentation for Number[sauf2] feature

### DIFF
--- a/_oge/feat/Number[sauf2].md
+++ b/_oge/feat/Number[sauf2].md
@@ -1,0 +1,31 @@
+---
+layout: feature
+title: 'Number[sauf2]'
+shortdef: 'double number Suffixaufnahme'
+udver: '2'
+---
+
+<table class="typeindex" border="1">
+<tr>
+  <td><a href="#Sing">Sing</a></td>
+  <td><a href="#Plur">Plur</a></td>
+</tr>
+</table>
+
+`Number[sauf2]` is an inflectional feature of [nouns](_oge/pos/NOUN), [proper nouns](_oge/pos/PROPN), [pronouns](_oge/pos/PRON), [adjectives](_oge/pos/ADJ), [numerals](_oge/pos/NUM), [verbs](_oge/pos/VERB) and [adpositions](_oge/pos/ADP). It consists of double *Suffixaufnahme*. In Old Georgian, *Suffixaufnahme* consists of the repetition of case and number endings of the head noun onto other nominals governed by it, and it mainly functions as a strategy for delimiting noun phrase constituency. It is also annotated with [`Case[sauf2]`](_oge/feat/Case[sauf2]).
+
+### <a name="Sing">`Sing`</a>: singular number
+
+Nominative singular case stacked to double genitive case.
+
+#### Examples
+
+* _სპარსთაჲსაჲ_ 'of Persians' (Gen with Gen and Nom Sing)  etc.
+
+### <a name="Plur">`Plur`</a>: plural number
+
+Nominative plural stacked to double genitive case.
+
+#### Examples
+
+* _ვეცხლისათანი_ 'of silver' (Gen with Gen and Nom Plur) etc.


### PR DESCRIPTION
Document the inflectional feature 'Number[sauf2]' with details on its usage in Old Georgian, including singular and plural examples for UD_Old_Georgian-LauRo