### PR TITLE
Add documentation for Number[sauf] feature

### DIFF
--- a/_oge/feat/Number-sauf.md
+++ b/_oge/feat/Number-sauf.md
@@ -1,0 +1,33 @@
+---
+layout: feature
+title: 'Number[sauf]'
+shortdef: 'number Suffixaufnahme'
+udver: '2'
+---
+
+<table class="typeindex" border="1">
+<tr>
+  <td><a href="#Sing">Sing</a></td>
+  <td><a href="#Plur">Plur</a></td>
+</tr>
+</table>
+
+`Number[sauf]` is an inflectional feature of [nouns](_oge/pos/NOUN), [proper nouns](_oge/pos/PROPN), [pronouns](_oge/pos/PRON), [adjectives](_oge/pos/ADJ), [numerals](_oge/pos/NUM), [verbs](_oge/pos/VERB) and [adpositions](_oge/pos/ADP). In Old Georgian, *Suffixaufnahme* consists of the repetition of case and number endings of the head noun onto other nominals governed by it, and it mainly functions as a strategy for delimiting noun phrase constituency. It is also annotated with [`Case[sauf]`](_oge/feat/Case[sauf]).
+Occasionally, *Suffixaufnahme* can be double, resulting in the stacking of three case endings. These are annotated with [`Number[sauf2]`](_oge/feat/Number[sauf2]).
+
+
+### <a name="Sing">`Sing`</a>: singular number
+
+Nominative singular case stacked to the genitive case.
+
+#### Examples
+
+* _ოქროჲსაჲ_ 'of gold' (Gen with Nom Sing)  etc.
+
+### <a name="Plur">`Plur`</a>: plural number
+
+Nominative plural case stacked to the genitive case.
+
+#### Examples
+
+* _ოქროჲსანი_ 'of gold' (Gen with Nom Plur) etc.


### PR DESCRIPTION
Document the inflectional feature 'Number[sauf]' in Old Georgian, detailing its function and examples for singular and plural forms. for UD_Old_Georgian-LauRo