### PR TITLE
Add documentation for Case[sauf2] feature

### DIFF
--- a/_oge/feat/Case-dsauf.md
+++ b/_oge/feat/Case-dsauf.md
@@ -1,6 +1,6 @@
 ---
 layout: feature
-title: 'Case[sauf2]'
+title: 'Case[dsauf]'
 shortdef: 'double Suffixaufnahme'
 udver: '2'
 ---
@@ -17,7 +17,7 @@ udver: '2'
 </tr>
 </table>
 
-`Case[sauf2]` is an inflectional feature of [nouns](_oge/pos/NOUN), [proper nouns](_oge/pos/PROPN), [pronouns](_oge/pos/PRON), [adjectives](_oge/pos/ADJ), [numerals](_oge/pos/NUM), [verbs](_oge/pos/VERB) and [adpositions](_oge/pos/ADP). It consists of double *Suffixaufnahme*. In Old Georgian, *Suffixaufnahme* consists of the repetition of case and number endings of the head noun onto other nominals governed by it, and it mainly functions as a strategy for delimiting noun phrase constituency. It is also annotated with [`Number[sauf2]`](_oge/feat/Number[sauf2]).
+`Case[sauf2]` is an inflectional feature of [nouns](_oge/pos/NOUN), [proper nouns](_oge/pos/PROPN), [pronouns](_oge/pos/PRON), [adjectives](_oge/pos/ADJ), [numerals](_oge/pos/NUM), [verbs](_oge/pos/VERB) and [adpositions](_oge/pos/ADP). It consists of double *Suffixaufnahme*. In Old Georgian, *Suffixaufnahme* consists of the repetition of case and number endings of the head noun onto other nominals governed by it, and it mainly functions as a strategy for delimiting noun phrase constituency. It is also annotated with [`Number[dsauf]`](_oge/feat/Number[dsauf]).
 
 ### <a name="Nom">`Nom`</a>: nominative case
 

--- a/_oge/feat/Case-sauf2.md
+++ b/_oge/feat/Case-sauf2.md
@@ -1,0 +1,52 @@
+---
+layout: feature
+title: 'Case[sauf2]'
+shortdef: 'double Suffixaufnahme'
+udver: '2'
+---
+
+<table class="typeindex" border="1">
+<tr>
+  <td><a href="#Nom">Nom</a></td>
+  <td><a href="#Erg">Erg</a></td>
+  <td><a href="#Gen">Gen</a></td>
+  <td><a href="#Dat">Dat</a></td>
+  <td><a href="#Ins">Ins</a></td>
+  <td><a href="#All">All</a></td>
+  <td><a href="#Voc">Voc</a></td>
+</tr>
+</table>
+
+`Case[sauf2]` is an inflectional feature of [nouns](_oge/pos/NOUN), [proper nouns](_oge/pos/PROPN), [pronouns](_oge/pos/PRON), [adjectives](_oge/pos/ADJ), [numerals](_oge/pos/NUM), [verbs](_oge/pos/VERB) and [adpositions](_oge/pos/ADP). It consists of double *Suffixaufnahme*. In Old Georgian, *Suffixaufnahme* consists of the repetition of case and number endings of the head noun onto other nominals governed by it, and it mainly functions as a strategy for delimiting noun phrase constituency. It is also annotated with [`Number[sauf2]`](_oge/feat/Number[sauf2]).
+
+### <a name="Nom">`Nom`</a>: nominative case
+
+Nominative case (singular or plural) stacked to double genitive case.
+
+#### Examples
+
+* _ნაბუისთაჲ_ 'of Nebo' (Gen with Gen and Nom)  etc.
+
+### <a name="Erg">`Erg`</a>: ergative case
+
+Ergative case (singular or plural) stacked to double genitive case.
+
+### <a name="Gen">`Gen`</a>: genitive case
+
+Genitive case (singular or plural) stacked to double genitive case.
+
+### <a name="Dat">`Dat`</a>: dative case
+
+Dative case (singular or plural) stacked to double genitive case.
+
+### <a name="Ins">`Ins`</a>: instrumental case
+
+Instrumental case stacked to double genitive case.
+
+### <a name="All">`All`</a>: adverbial case
+
+Adverbial case stacked to double genitive case.
+
+### <a name="Voc">`Voc`</a>: vocative case
+
+Vocative case (singular or plural) stacked to double genitive case.


### PR DESCRIPTION
This document details the inflectional feature 'Case[sauf2]' in Old Georgian, explaining its structure and usage across various grammatical categories. for UD_Old_Georgian-LauRo